### PR TITLE
Decode Claude's scoped per-model limits into labeled weekly windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   usage endpoint's `limits` array. Because the menu-bar badge tracks
   the tightest window, an exhausted per-model pool now surfaces there
   instead of hiding behind a comfortable all-models number.
+- Claude scoped-limit decoding now keeps distinct model identities separate
+  and degrades safely when the optional provider payload drifts.
 
 ## 0.2.4 - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Claude accounts now show per-model weekly pools (currently the Fable
+  share of the weekly limit) as labeled weekly rows, read from the
+  usage endpoint's `limits` array. Because the menu-bar badge tracks
+  the tightest window, an exhausted per-model pool now surfaces there
+  instead of hiding behind a comfortable all-models number.
+
 ## 0.2.4 - 2026-08-07
 
 ### Added

--- a/Sources/ClaudeWebProbe/ClaudeWebProbeModel.swift
+++ b/Sources/ClaudeWebProbe/ClaudeWebProbeModel.swift
@@ -36,6 +36,7 @@ struct ClaudeWebProbeWindow: Codable, Equatable {
   let duration: TimeInterval
   let consumedFraction: Double
   let resetAt: Date?
+  let label: String?
 }
 
 struct ClaudeWebProbeOutput: Codable, Equatable {
@@ -55,7 +56,8 @@ struct ClaudeWebProbeOutput: Codable, Equatable {
         kind: $0.kind,
         duration: $0.duration,
         consumedFraction: $0.consumedFraction,
-        resetAt: $0.resetAt
+        resetAt: $0.resetAt,
+        label: $0.label
       )
     }
   }

--- a/Sources/UsageMeterCore/Providers/ClaudeUsageDecoder.swift
+++ b/Sources/UsageMeterCore/Providers/ClaudeUsageDecoder.swift
@@ -167,8 +167,17 @@ public struct ClaudeUsageDecoder: Sendable {
     private func scopedWindows(
         from payload: UsagePayload
     ) -> [UsageWindow] {
-        guard let limits = payload.limits else {
+        let limits: [LossyLimitPayload]
+        switch payload.limits {
+        case .absent:
             return []
+        case .malformed:
+            claudeLogger.error(
+                "Skipped malformed scoped limit entries: count=\(1, privacy: .public)"
+            )
+            return []
+        case .values(let decodedLimits):
+            limits = decodedLimits
         }
         var windows: [UsageWindow] = []
         var indexByID: [String: Int] = [:]
@@ -179,29 +188,43 @@ public struct ClaudeUsageDecoder: Sendable {
                 continue
             }
             guard
-                let model = normalizedModelName(of: limit),
                 limit.group == "weekly"
             else {
+                continue
+            }
+            guard let scope = limit.scope else {
+                continue
+            }
+            guard let model = scope.model else {
+                malformedEntries += 1
+                continue
+            }
+            let displayName = Self.normalizedText(model.displayName)
+            let modelID = Self.normalizedText(model.id)
+            guard
+                let identity = modelID.map({ "id:\($0)" })
+                    ?? displayName.map({ "name:\($0)" }),
+                let label = displayName ?? modelID
+            else {
+                malformedEntries += 1
                 continue
             }
             guard
                 Self.isValidUtilization(limit.percent),
                 let window = UsageWindow(
-                    id: "claude-weekly-scoped-\(Self.slug(model))",
+                    id: "claude-weekly-scoped-\(Self.stableIdentifierComponent(identity))",
                     kind: .weekly,
                     duration: 604_800,
                     resetAt: limit.resetsAt,
                     consumedFraction: limit.percent / 100,
-                    label: model,
+                    label: label,
                 )
             else {
                 malformedEntries += 1
                 continue
             }
             if let existing = indexByID[window.id] {
-                if window.consumedFraction
-                    > windows[existing].consumedFraction
-                {
+                if Self.shouldPrefer(window, over: windows[existing]) {
                     windows[existing] = window
                 }
             } else {
@@ -217,28 +240,39 @@ public struct ClaudeUsageDecoder: Sendable {
         return windows
     }
 
-    private func normalizedModelName(
-        of limit: LimitPayload
-    ) -> String? {
-        guard
-            let name = limit.scope?.model?.displayName?
-                .trimmingCharacters(in: .whitespacesAndNewlines),
-            !name.isEmpty
-        else {
+    private static func normalizedText(_ value: String?) -> String? {
+        guard let value else {
             return nil
         }
-        return name
+        let normalized = value.trimmingCharacters(
+            in: .whitespacesAndNewlines,
+        )
+        return normalized.isEmpty ? nil : normalized
     }
 
-    private static func slug(_ value: String) -> String {
-        value
-            .lowercased()
-            .map { character in
-                character.isLetter || character.isNumber
-                    ? String(character)
-                    : "-"
-            }
+    private static func stableIdentifierComponent(_ value: String) -> String {
+        Data(value.utf8)
+            .map { String(format: "%02x", $0) }
             .joined()
+    }
+
+    private static func shouldPrefer(
+        _ candidate: UsageWindow,
+        over existing: UsageWindow,
+    ) -> Bool {
+        if candidate.consumedFraction != existing.consumedFraction {
+            return candidate.consumedFraction > existing.consumedFraction
+        }
+        switch (candidate.resetAt, existing.resetAt) {
+        case (_?, nil):
+            return true
+        case (nil, _?):
+            return false
+        case (let candidateReset?, let existingReset?):
+            return candidateReset < existingReset
+        case (nil, nil):
+            return false
+        }
     }
 
     private func normalizedBalances(
@@ -302,7 +336,7 @@ private struct UsagePayload: Decodable {
     let sevenDay: WindowPayload
     let extraUsage: ExtraUsagePayload?
     let spend: SpendPayload?
-    let limits: [LossyLimitPayload]?
+    let limits: LimitsPayload
 
     private enum CodingKeys: String, CodingKey {
         case fiveHour = "five_hour"
@@ -333,11 +367,29 @@ private struct UsagePayload: Decodable {
         // A drifted `limits` container (present but not an array)
         // degrades like a drifted element: scoped limits are optional
         // surface and must never black out the legacy windows.
-        limits = try? container.decode(
-            [LossyLimitPayload].self,
-            forKey: .limits
-        )
+        if !container.contains(.limits) {
+            limits = .absent
+        } else if try container.decodeNil(forKey: .limits) {
+            limits = .absent
+        } else {
+            do {
+                limits = .values(
+                    try container.decode(
+                        [LossyLimitPayload].self,
+                        forKey: .limits,
+                    ),
+                )
+            } catch {
+                limits = .malformed
+            }
+        }
     }
+}
+
+private enum LimitsPayload {
+    case absent
+    case malformed
+    case values([LossyLimitPayload])
 }
 
 // A limit entry that fails to decode becomes nil instead of failing
@@ -370,9 +422,11 @@ private struct ScopePayload: Decodable {
 }
 
 private struct ModelScopePayload: Decodable {
+    let id: String?
     let displayName: String?
 
     private enum CodingKeys: String, CodingKey {
+        case id
         case displayName = "display_name"
     }
 }

--- a/Sources/UsageMeterCore/Providers/ClaudeUsageDecoder.swift
+++ b/Sources/UsageMeterCore/Providers/ClaudeUsageDecoder.swift
@@ -156,9 +156,14 @@ public struct ClaudeUsageDecoder: Sendable {
     // surface on top of the qualified legacy contract, so anything
     // unusable is skipped — never a reason to reject the response.
     // Unscoped entries mirror the legacy windows and would
-    // double-render; unknown groups are future provider surface; a
-    // nonzero percent without a reset violates the no-invented-reset
-    // invariant and is dropped by the UsageWindow initializer.
+    // double-render, and non-weekly groups are unqualified surface;
+    // both are expected and pass silently. Only malformed entries are
+    // counted and logged: an undecodable element, an out-of-range
+    // percent, or a nonzero percent without a reset (which the
+    // UsageWindow initializer drops per the no-invented-reset
+    // invariant). Entries that collide on id resolve to the
+    // higher-consumed one, so a duplicate can only tighten the
+    // reported limit, never hide it.
     private func scopedWindows(
         from payload: UsagePayload
     ) -> [UsageWindow] {
@@ -166,51 +171,51 @@ public struct ClaudeUsageDecoder: Sendable {
             return []
         }
         var windows: [UsageWindow] = []
-        var seenIDs: Set<String> = []
-        var skippedEntries = 0
+        var indexByID: [String: Int] = [:]
+        var malformedEntries = 0
         for entry in limits {
             guard let limit = entry.value else {
-                skippedEntries += 1
+                malformedEntries += 1
                 continue
             }
-            guard let model = normalizedModelName(of: limit) else {
-                continue
-            }
-            guard let shape = Self.scopedGroupShapes[limit.group] else {
+            guard
+                let model = normalizedModelName(of: limit),
+                limit.group == "weekly"
+            else {
                 continue
             }
             guard
                 Self.isValidUtilization(limit.percent),
                 let window = UsageWindow(
-                    id: "claude-\(limit.group)-scoped-\(Self.slug(model))",
-                    kind: shape.kind,
-                    duration: shape.duration,
+                    id: "claude-weekly-scoped-\(Self.slug(model))",
+                    kind: .weekly,
+                    duration: 604_800,
                     resetAt: limit.resetsAt,
                     consumedFraction: limit.percent / 100,
                     label: model,
-                ),
-                seenIDs.insert(window.id).inserted
+                )
             else {
-                skippedEntries += 1
+                malformedEntries += 1
                 continue
             }
-            windows.append(window)
+            if let existing = indexByID[window.id] {
+                if window.consumedFraction
+                    > windows[existing].consumedFraction
+                {
+                    windows[existing] = window
+                }
+            } else {
+                indexByID[window.id] = windows.count
+                windows.append(window)
+            }
         }
-        if skippedEntries > 0 {
+        if malformedEntries > 0 {
             claudeLogger.error(
-                "Skipped scoped limit entries: count=\(skippedEntries, privacy: .public)"
+                "Skipped malformed scoped limit entries: count=\(malformedEntries, privacy: .public)"
             )
         }
         return windows
     }
-
-    private static let scopedGroupShapes: [String: (
-        kind: UsageWindowKind,
-        duration: TimeInterval
-    )] = [
-        "session": (kind: .short, duration: 18_000),
-        "weekly": (kind: .weekly, duration: 604_800),
-    ]
 
     private func normalizedModelName(
         of limit: LimitPayload
@@ -305,6 +310,33 @@ private struct UsagePayload: Decodable {
         case extraUsage = "extra_usage"
         case spend
         case limits
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        fiveHour = try container.decode(
+            WindowPayload.self,
+            forKey: .fiveHour
+        )
+        sevenDay = try container.decode(
+            WindowPayload.self,
+            forKey: .sevenDay
+        )
+        extraUsage = try container.decodeIfPresent(
+            ExtraUsagePayload.self,
+            forKey: .extraUsage
+        )
+        spend = try container.decodeIfPresent(
+            SpendPayload.self,
+            forKey: .spend
+        )
+        // A drifted `limits` container (present but not an array)
+        // degrades like a drifted element: scoped limits are optional
+        // surface and must never black out the legacy windows.
+        limits = try? container.decode(
+            [LossyLimitPayload].self,
+            forKey: .limits
+        )
     }
 }
 

--- a/Sources/UsageMeterCore/Providers/ClaudeUsageDecoder.swift
+++ b/Sources/UsageMeterCore/Providers/ClaudeUsageDecoder.swift
@@ -62,7 +62,7 @@ public struct ClaudeUsageDecoder: Sendable {
         return UsageSnapshot(
             accountID: accountID,
             fetchedAt: fetchedAt,
-            windows: [shortWindow, weeklyWindow],
+            windows: [shortWindow, weeklyWindow] + scopedWindows(from: payload),
             balances: balances,
         )
     }
@@ -150,6 +150,92 @@ public struct ClaudeUsageDecoder: Sendable {
         )
     }
 
+    // The `limits` array is the only place the provider reports
+    // per-model pools (for example the Fable weekly share); the legacy
+    // top-level windows never carry them. Scoped entries are optional
+    // surface on top of the qualified legacy contract, so anything
+    // unusable is skipped — never a reason to reject the response.
+    // Unscoped entries mirror the legacy windows and would
+    // double-render; unknown groups are future provider surface; a
+    // nonzero percent without a reset violates the no-invented-reset
+    // invariant and is dropped by the UsageWindow initializer.
+    private func scopedWindows(
+        from payload: UsagePayload
+    ) -> [UsageWindow] {
+        guard let limits = payload.limits else {
+            return []
+        }
+        var windows: [UsageWindow] = []
+        var seenIDs: Set<String> = []
+        var skippedEntries = 0
+        for entry in limits {
+            guard let limit = entry.value else {
+                skippedEntries += 1
+                continue
+            }
+            guard let model = normalizedModelName(of: limit) else {
+                continue
+            }
+            guard let shape = Self.scopedGroupShapes[limit.group] else {
+                continue
+            }
+            guard
+                Self.isValidUtilization(limit.percent),
+                let window = UsageWindow(
+                    id: "claude-\(limit.group)-scoped-\(Self.slug(model))",
+                    kind: shape.kind,
+                    duration: shape.duration,
+                    resetAt: limit.resetsAt,
+                    consumedFraction: limit.percent / 100,
+                    label: model,
+                ),
+                seenIDs.insert(window.id).inserted
+            else {
+                skippedEntries += 1
+                continue
+            }
+            windows.append(window)
+        }
+        if skippedEntries > 0 {
+            claudeLogger.error(
+                "Skipped scoped limit entries: count=\(skippedEntries, privacy: .public)"
+            )
+        }
+        return windows
+    }
+
+    private static let scopedGroupShapes: [String: (
+        kind: UsageWindowKind,
+        duration: TimeInterval
+    )] = [
+        "session": (kind: .short, duration: 18_000),
+        "weekly": (kind: .weekly, duration: 604_800),
+    ]
+
+    private func normalizedModelName(
+        of limit: LimitPayload
+    ) -> String? {
+        guard
+            let name = limit.scope?.model?.displayName?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+            !name.isEmpty
+        else {
+            return nil
+        }
+        return name
+    }
+
+    private static func slug(_ value: String) -> String {
+        value
+            .lowercased()
+            .map { character in
+                character.isLetter || character.isNumber
+                    ? String(character)
+                    : "-"
+            }
+            .joined()
+    }
+
     private func normalizedBalances(
         from payload: UsagePayload,
     ) throws -> [UsageBalance] {
@@ -211,12 +297,51 @@ private struct UsagePayload: Decodable {
     let sevenDay: WindowPayload
     let extraUsage: ExtraUsagePayload?
     let spend: SpendPayload?
+    let limits: [LossyLimitPayload]?
 
     private enum CodingKeys: String, CodingKey {
         case fiveHour = "five_hour"
         case sevenDay = "seven_day"
         case extraUsage = "extra_usage"
         case spend
+        case limits
+    }
+}
+
+// A limit entry that fails to decode becomes nil instead of failing
+// the whole response: scoped limits are optional surface, and one
+// drifted entry must not black out an account's legacy windows.
+private struct LossyLimitPayload: Decodable {
+    let value: LimitPayload?
+
+    init(from decoder: Decoder) {
+        value = try? LimitPayload(from: decoder)
+    }
+}
+
+private struct LimitPayload: Decodable {
+    let group: String
+    let percent: Double
+    let resetsAt: Date?
+    let scope: ScopePayload?
+
+    private enum CodingKeys: String, CodingKey {
+        case group
+        case percent
+        case resetsAt = "resets_at"
+        case scope
+    }
+}
+
+private struct ScopePayload: Decodable {
+    let model: ModelScopePayload?
+}
+
+private struct ModelScopePayload: Decodable {
+    let displayName: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case displayName = "display_name"
     }
 }
 

--- a/Sources/UsageMeterProbe/ProbeOutput.swift
+++ b/Sources/UsageMeterProbe/ProbeOutput.swift
@@ -25,6 +25,7 @@ struct ProbeWindow: Codable, Equatable {
   let consumedPercent: Int
   let remainingFraction: Double
   let resetAt: Date?
+  let label: String?
 
   init(window: UsageWindow) {
     kind = window.kind
@@ -32,5 +33,6 @@ struct ProbeWindow: Codable, Equatable {
     consumedPercent = Int((window.consumedFraction * 100).rounded())
     remainingFraction = window.remainingFraction
     resetAt = window.resetAt
+    label = window.label
   }
 }

--- a/Tests/ClaudeWebProbeTests/ClaudeWebProbeModelTests.swift
+++ b/Tests/ClaudeWebProbeTests/ClaudeWebProbeModelTests.swift
@@ -72,7 +72,8 @@ struct ClaudeWebProbeModelTests {
           kind: .short,
           duration: 18_000,
           consumedFraction: 0.42,
-          resetAt: resetAt
+          resetAt: resetAt,
+          label: nil
         )
       ]
     )

--- a/Tests/ClaudeWebProbeTests/ClaudeWebProbeModelTests.swift
+++ b/Tests/ClaudeWebProbeTests/ClaudeWebProbeModelTests.swift
@@ -108,6 +108,32 @@ struct ClaudeWebProbeModelTests {
   }
 
   @Test
+  func outputPreservesScopedWindowLabel() throws {
+    let resetAt = Date(timeIntervalSince1970: 2_000_000_000)
+    let window = try #require(
+      UsageWindow(
+        id: "claude-weekly-scoped-6e616d653a4661626c65",
+        kind: .weekly,
+        duration: 604_800,
+        resetAt: resetAt,
+        consumedFraction: 0.42,
+        label: "Fable",
+      ),
+    )
+    let output = ClaudeWebProbeOutput(
+      profileID: UUID(),
+      organizationCount: 1,
+      snapshot: UsageSnapshot(
+        accountID: UUID(),
+        fetchedAt: resetAt.addingTimeInterval(-60),
+        windows: [window],
+      ),
+    )
+
+    #expect(output.windows.first?.label == "Fable")
+  }
+
+  @Test
   func trackerCompatibleSelectionDoesNotAskBetweenDuplicateNames() {
     let first = ClaudeOrganization(
       id: UUID(),

--- a/Tests/UsageMeterClaudeWebTests/ClaudeWebUsageClientTests.swift
+++ b/Tests/UsageMeterClaudeWebTests/ClaudeWebUsageClientTests.swift
@@ -163,8 +163,11 @@ struct ClaudeWebUsageClientTests {
 
         #expect(snapshot.accountID == accountID)
         #expect(snapshot.fetchedAt == fetchedAt)
-        #expect(snapshot.windows.map(\.kind) == [.short, .weekly])
-        #expect(snapshot.windows.map(\.duration) == [18_000, 604_800])
+        #expect(snapshot.windows.map(\.kind) == [.short, .weekly, .weekly])
+        #expect(
+            snapshot.windows.map(\.duration) == [18_000, 604_800, 604_800]
+        )
+        #expect(snapshot.windows.map(\.label) == [nil, nil, "Fable"])
         let request = try #require(await transport.lastRequest)
         #expect(
             request.url?.absoluteString

--- a/Tests/UsageMeterClaudeWebTests/Fixtures/claude-usage.json
+++ b/Tests/UsageMeterClaudeWebTests/Fixtures/claude-usage.json
@@ -6,5 +6,55 @@
   "seven_day": {
     "utilization": 66.0,
     "resets_at": "2026-08-03T21:40:00Z"
-  }
+  },
+  "limits": [
+    {
+      "kind": "session",
+      "group": "session",
+      "percent": 81,
+      "severity": "normal",
+      "resets_at": "2026-07-29T20:23:00Z",
+      "scope": null,
+      "is_active": false
+    },
+    {
+      "kind": "weekly_all",
+      "group": "weekly",
+      "percent": 66,
+      "severity": "normal",
+      "resets_at": "2026-08-03T21:40:00Z",
+      "scope": null,
+      "is_active": false
+    },
+    {
+      "kind": "weekly_scoped",
+      "group": "weekly",
+      "percent": 42,
+      "severity": "normal",
+      "resets_at": "2026-08-03T21:40:00Z",
+      "scope": {
+        "model": {
+          "id": null,
+          "display_name": "Fable"
+        },
+        "surface": null
+      },
+      "is_active": true
+    },
+    {
+      "kind": "epoch_scoped",
+      "group": "epoch",
+      "percent": 10,
+      "severity": "normal",
+      "resets_at": "2026-08-03T21:40:00Z",
+      "scope": {
+        "model": {
+          "id": null,
+          "display_name": "Fable"
+        },
+        "surface": null
+      },
+      "is_active": true
+    }
+  ]
 }

--- a/Tests/UsageMeterCoreTests/AppStateStoreTests.swift
+++ b/Tests/UsageMeterCoreTests/AppStateStoreTests.swift
@@ -126,10 +126,20 @@ private func makePersistedState() throws -> PersistedAppState {
             consumedFraction: 0.42,
         ),
     )
+    let scopedWindow = try #require(
+        UsageWindow(
+            id: "claude-weekly-scoped-6e616d653a4661626c65",
+            kind: .weekly,
+            duration: 604_800,
+            resetAt: Date(timeIntervalSince1970: 2_000_000_000),
+            consumedFraction: 0.84,
+            label: "Fable",
+        ),
+    )
     let snapshot = UsageSnapshot(
         accountID: account.id,
         fetchedAt: Date(timeIntervalSince1970: 1_999_999_000),
-        windows: [window],
+        windows: [window, scopedWindow],
     )
 
     return PersistedAppState(

--- a/Tests/UsageMeterCoreTests/ClaudeUsageClientTests.swift
+++ b/Tests/UsageMeterCoreTests/ClaudeUsageClientTests.swift
@@ -41,7 +41,10 @@ struct ClaudeUsageClientTests {
             snapshot.windows[1].resetAt
                 == Date(timeIntervalSince1970: 1_785_793_200)
         )
-        #expect(snapshot.windows[2].id == "claude-weekly-scoped-fable")
+        #expect(
+            snapshot.windows[2].id
+                == "claude-weekly-scoped-6e616d653a4661626c65"
+        )
         #expect(snapshot.windows[2].label == "Fable")
 
         let request = try #require(await transport.lastRequest)

--- a/Tests/UsageMeterCoreTests/ClaudeUsageClientTests.swift
+++ b/Tests/UsageMeterCoreTests/ClaudeUsageClientTests.swift
@@ -26,7 +26,7 @@ struct ClaudeUsageClientTests {
 
         #expect(snapshot.accountID == accountID)
         #expect(snapshot.fetchedAt == fetchedAt)
-        #expect(snapshot.windows.count == 2)
+        #expect(snapshot.windows.count == 3)
         #expect(snapshot.windows[0].kind == .short)
         #expect(snapshot.windows[0].duration == 18_000)
         #expect(snapshot.windows[0].consumedFraction == 0.81)
@@ -41,6 +41,8 @@ struct ClaudeUsageClientTests {
             snapshot.windows[1].resetAt
                 == Date(timeIntervalSince1970: 1_785_793_200)
         )
+        #expect(snapshot.windows[2].id == "claude-weekly-scoped-fable")
+        #expect(snapshot.windows[2].label == "Fable")
 
         let request = try #require(await transport.lastRequest)
         #expect(request.httpMethod == "GET")

--- a/Tests/UsageMeterCoreTests/ClaudeUsageDecoderTests.swift
+++ b/Tests/UsageMeterCoreTests/ClaudeUsageDecoderTests.swift
@@ -55,6 +55,17 @@ struct ClaudeUsageDecoderTests {
                   "is_active": false
                 },
                 {
+                  "kind": "session_scoped",
+                  "group": "session",
+                  "percent": 15,
+                  "resets_at": "2026-08-01T00:00:00Z",
+                  "scope": {
+                    "model": {"id": null, "display_name": "Fable"},
+                    "surface": null
+                  },
+                  "is_active": true
+                },
+                {
                   "kind": "weekly_scoped",
                   "group": "weekly",
                   "percent": "not-a-number",
@@ -110,14 +121,48 @@ struct ClaudeUsageDecoderTests {
         )
 
         // The unscoped entry duplicates the legacy weekly window, the
+        // scoped session-group entry is unqualified surface, and the
         // malformed percent and the nonzero resetless entry are
-        // dropped, and only the first valid Fable entry survives the
-        // duplicate-id guard. Its inactive flag does not hide it: the
-        // provider reports real percents on inactive scoped entries.
+        // dropped. The two valid Fable entries collide on id and
+        // resolve to the higher-consumed one, so a duplicate can only
+        // tighten the reported limit; the loser's inactive flag is
+        // irrelevant because the provider reports real percents on
+        // inactive scoped entries too.
         #expect(snapshot.windows.count == 3)
         #expect(snapshot.windows[2].id == "claude-weekly-scoped-fable")
-        #expect(snapshot.windows[2].consumedFraction == 0.35)
+        #expect(snapshot.windows[2].consumedFraction == 0.5)
         #expect(snapshot.windows[2].label == "Fable")
+    }
+
+    @Test
+    func driftedLimitsContainerDoesNotRejectTheLegacyWindows() throws {
+        for limits in ["{}", "3", "\"drifted\"", "null"] {
+            let data = Data(
+                """
+                {
+                  "five_hour": {
+                    "utilization": 10,
+                    "resets_at": "2026-08-01T00:00:00Z"
+                  },
+                  "seven_day": {
+                    "utilization": 20,
+                    "resets_at": "2026-08-03T00:00:00Z"
+                  },
+                  "limits": \(limits)
+                }
+                """.utf8,
+            )
+
+            let snapshot = try ClaudeUsageDecoder().decode(
+                data,
+                accountID: UUID(),
+                fetchedAt: Date(timeIntervalSince1970: 2_000_000_000),
+            )
+
+            #expect(
+                snapshot.windows.map(\.id) == ["five-hour", "seven-day"]
+            )
+        }
     }
 
     @Test

--- a/Tests/UsageMeterCoreTests/ClaudeUsageDecoderTests.swift
+++ b/Tests/UsageMeterCoreTests/ClaudeUsageDecoderTests.swift
@@ -18,13 +18,132 @@ struct ClaudeUsageDecoderTests {
 
         #expect(snapshot.accountID == accountID)
         #expect(snapshot.fetchedAt == fetchedAt)
-        #expect(snapshot.windows.count == 2)
+        #expect(snapshot.windows.count == 3)
         #expect(snapshot.windows[0].kind == .short)
         #expect(snapshot.windows[0].duration == 18_000)
         #expect(snapshot.windows[0].consumedFraction == 0.81)
         #expect(snapshot.windows[1].kind == .weekly)
         #expect(snapshot.windows[1].duration == 604_800)
         #expect(snapshot.windows[1].consumedFraction == 0.66)
+        #expect(snapshot.windows[2].id == "claude-weekly-scoped-fable")
+        #expect(snapshot.windows[2].kind == .weekly)
+        #expect(snapshot.windows[2].duration == 604_800)
+        #expect(snapshot.windows[2].consumedFraction == 0.42)
+        #expect(snapshot.windows[2].label == "Fable")
+    }
+
+    @Test
+    func scopedLimitEntriesAreFilteredWithoutRejectingTheResponse() throws {
+        let data = Data(
+            """
+            {
+              "five_hour": {
+                "utilization": 10,
+                "resets_at": "2026-08-01T00:00:00Z"
+              },
+              "seven_day": {
+                "utilization": 20,
+                "resets_at": "2026-08-03T00:00:00Z"
+              },
+              "limits": [
+                {
+                  "kind": "weekly_all",
+                  "group": "weekly",
+                  "percent": 20,
+                  "resets_at": "2026-08-03T00:00:00Z",
+                  "scope": null,
+                  "is_active": false
+                },
+                {
+                  "kind": "weekly_scoped",
+                  "group": "weekly",
+                  "percent": "not-a-number",
+                  "resets_at": "2026-08-03T00:00:00Z",
+                  "scope": {
+                    "model": {"id": null, "display_name": "Fable"},
+                    "surface": null
+                  },
+                  "is_active": true
+                },
+                {
+                  "kind": "weekly_scoped",
+                  "group": "weekly",
+                  "percent": 40,
+                  "resets_at": null,
+                  "scope": {
+                    "model": {"id": null, "display_name": "Fable"},
+                    "surface": null
+                  },
+                  "is_active": true
+                },
+                {
+                  "kind": "weekly_scoped",
+                  "group": "weekly",
+                  "percent": 35,
+                  "resets_at": "2026-08-03T00:00:00Z",
+                  "scope": {
+                    "model": {"id": null, "display_name": "Fable"},
+                    "surface": null
+                  },
+                  "is_active": false
+                },
+                {
+                  "kind": "weekly_scoped",
+                  "group": "weekly",
+                  "percent": 50,
+                  "resets_at": "2026-08-03T00:00:00Z",
+                  "scope": {
+                    "model": {"id": null, "display_name": "Fable"},
+                    "surface": null
+                  },
+                  "is_active": true
+                }
+              ]
+            }
+            """.utf8,
+        )
+
+        let snapshot = try ClaudeUsageDecoder().decode(
+            data,
+            accountID: UUID(),
+            fetchedAt: Date(timeIntervalSince1970: 2_000_000_000),
+        )
+
+        // The unscoped entry duplicates the legacy weekly window, the
+        // malformed percent and the nonzero resetless entry are
+        // dropped, and only the first valid Fable entry survives the
+        // duplicate-id guard. Its inactive flag does not hide it: the
+        // provider reports real percents on inactive scoped entries.
+        #expect(snapshot.windows.count == 3)
+        #expect(snapshot.windows[2].id == "claude-weekly-scoped-fable")
+        #expect(snapshot.windows[2].consumedFraction == 0.35)
+        #expect(snapshot.windows[2].label == "Fable")
+    }
+
+    @Test
+    func responseWithoutLimitsKeepsTheLegacyWindowPair() throws {
+        let data = Data(
+            """
+            {
+              "five_hour": {
+                "utilization": 10,
+                "resets_at": "2026-08-01T00:00:00Z"
+              },
+              "seven_day": {
+                "utilization": 20,
+                "resets_at": "2026-08-03T00:00:00Z"
+              }
+            }
+            """.utf8,
+        )
+
+        let snapshot = try ClaudeUsageDecoder().decode(
+            data,
+            accountID: UUID(),
+            fetchedAt: Date(timeIntervalSince1970: 2_000_000_000),
+        )
+
+        #expect(snapshot.windows.map(\.id) == ["five-hour", "seven-day"])
     }
 
     @Test

--- a/Tests/UsageMeterCoreTests/ClaudeUsageDecoderTests.swift
+++ b/Tests/UsageMeterCoreTests/ClaudeUsageDecoderTests.swift
@@ -25,7 +25,10 @@ struct ClaudeUsageDecoderTests {
         #expect(snapshot.windows[1].kind == .weekly)
         #expect(snapshot.windows[1].duration == 604_800)
         #expect(snapshot.windows[1].consumedFraction == 0.66)
-        #expect(snapshot.windows[2].id == "claude-weekly-scoped-fable")
+        #expect(
+            snapshot.windows[2].id
+                == "claude-weekly-scoped-6e616d653a4661626c65"
+        )
         #expect(snapshot.windows[2].kind == .weekly)
         #expect(snapshot.windows[2].duration == 604_800)
         #expect(snapshot.windows[2].consumedFraction == 0.42)
@@ -129,9 +132,125 @@ struct ClaudeUsageDecoderTests {
         // irrelevant because the provider reports real percents on
         // inactive scoped entries too.
         #expect(snapshot.windows.count == 3)
-        #expect(snapshot.windows[2].id == "claude-weekly-scoped-fable")
+        #expect(
+            snapshot.windows[2].id
+                == "claude-weekly-scoped-6e616d653a4661626c65"
+        )
         #expect(snapshot.windows[2].consumedFraction == 0.5)
         #expect(snapshot.windows[2].label == "Fable")
+    }
+
+    @Test
+    func scopedModelIdentitiesDoNotCollapseDisplayNameCollisions() throws {
+        let data = Data(
+            """
+            {
+              "five_hour": {
+                "utilization": 10,
+                "resets_at": "2026-08-01T00:00:00Z"
+              },
+              "seven_day": {
+                "utilization": 20,
+                "resets_at": "2026-08-03T00:00:00Z"
+              },
+              "limits": [
+                {
+                  "group": "weekly",
+                  "percent": 20,
+                  "resets_at": "2026-08-03T00:00:00Z",
+                  "scope": {
+                    "model": {"id": null, "display_name": "Foo Bar"}
+                  }
+                },
+                {
+                  "group": "weekly",
+                  "percent": 30,
+                  "resets_at": "2026-08-03T00:00:00Z",
+                  "scope": {
+                    "model": {"id": null, "display_name": "Foo-Bar"}
+                  }
+                },
+                {
+                  "group": "weekly",
+                  "percent": 40,
+                  "resets_at": "2026-08-03T00:00:00Z",
+                  "scope": {
+                    "model": {"id": "model-123", "display_name": null}
+                  }
+                }
+              ]
+            }
+            """.utf8,
+        )
+
+        let snapshot = try ClaudeUsageDecoder().decode(
+            data,
+            accountID: UUID(),
+            fetchedAt: Date(timeIntervalSince1970: 2_000_000_000),
+        )
+
+        let scopedWindows = Array(snapshot.windows.dropFirst(2))
+        #expect(scopedWindows.count == 3)
+        #expect(
+            scopedWindows.map(\.id)
+                == [
+                    "claude-weekly-scoped-6e616d653a466f6f20426172",
+                    "claude-weekly-scoped-6e616d653a466f6f2d426172",
+                    "claude-weekly-scoped-69643a6d6f64656c2d313233",
+                ]
+        )
+        #expect(
+            scopedWindows.map(\.label)
+                == ["Foo Bar", "Foo-Bar", "model-123"]
+        )
+    }
+
+    @Test
+    func duplicateScopedWindowsPreferAConcreteResetWhenUsageTies() throws {
+        let data = Data(
+            """
+            {
+              "five_hour": {
+                "utilization": 10,
+                "resets_at": "2026-08-01T00:00:00Z"
+              },
+              "seven_day": {
+                "utilization": 20,
+                "resets_at": "2026-08-03T00:00:00Z"
+              },
+              "limits": [
+                {
+                  "group": "weekly",
+                  "percent": 0,
+                  "resets_at": null,
+                  "scope": {
+                    "model": {"id": "model-123", "display_name": "Fable"}
+                  }
+                },
+                {
+                  "group": "weekly",
+                  "percent": 0,
+                  "resets_at": "2026-08-03T00:00:00Z",
+                  "scope": {
+                    "model": {"id": "model-123", "display_name": "Fable"}
+                  }
+                }
+              ]
+            }
+            """.utf8,
+        )
+
+        let snapshot = try ClaudeUsageDecoder().decode(
+            data,
+            accountID: UUID(),
+            fetchedAt: Date(timeIntervalSince1970: 2_000_000_000),
+        )
+
+        #expect(snapshot.windows.count == 3)
+        #expect(
+            snapshot.windows[2].resetAt
+                == Date(timeIntervalSince1970: 1_785_715_200)
+        )
     }
 
     @Test

--- a/Tests/UsageMeterCoreTests/Fixtures/claude-usage.json
+++ b/Tests/UsageMeterCoreTests/Fixtures/claude-usage.json
@@ -6,5 +6,55 @@
   "seven_day": {
     "utilization": 66.0,
     "resets_at": "2026-08-03T21:40:00Z"
-  }
+  },
+  "limits": [
+    {
+      "kind": "session",
+      "group": "session",
+      "percent": 81,
+      "severity": "normal",
+      "resets_at": "2026-07-29T20:23:00Z",
+      "scope": null,
+      "is_active": false
+    },
+    {
+      "kind": "weekly_all",
+      "group": "weekly",
+      "percent": 66,
+      "severity": "normal",
+      "resets_at": "2026-08-03T21:40:00Z",
+      "scope": null,
+      "is_active": false
+    },
+    {
+      "kind": "weekly_scoped",
+      "group": "weekly",
+      "percent": 42,
+      "severity": "normal",
+      "resets_at": "2026-08-03T21:40:00Z",
+      "scope": {
+        "model": {
+          "id": null,
+          "display_name": "Fable"
+        },
+        "surface": null
+      },
+      "is_active": true
+    },
+    {
+      "kind": "epoch_scoped",
+      "group": "epoch",
+      "percent": 10,
+      "severity": "normal",
+      "resets_at": "2026-08-03T21:40:00Z",
+      "scope": {
+        "model": {
+          "id": null,
+          "display_name": "Fable"
+        },
+        "surface": null
+      },
+      "is_active": true
+    }
+  ]
 }

--- a/Tests/UsageMeterCoreTests/UsageSummaryTests.swift
+++ b/Tests/UsageMeterCoreTests/UsageSummaryTests.swift
@@ -162,3 +162,40 @@ func balancesDoNotParticipateInTightestWindowSelection() throws {
       == TightestUsage(accountID: accountID, window: weekly),
   )
 }
+
+@Test
+func inactiveScopedWindowParticipatesInTightestWindowSelection() throws {
+  let now = Date(timeIntervalSince1970: 2_000_000_000)
+  let accountID = UUID()
+  let legacy = try #require(
+    UsageWindow(
+      id: "seven-day",
+      kind: .weekly,
+      duration: 604_800,
+      resetAt: now.addingTimeInterval(604_800),
+      consumedFraction: 0.67,
+    ),
+  )
+  let scoped = try #require(
+    UsageWindow(
+      id: "claude-weekly-scoped-6e616d653a4661626c65",
+      kind: .weekly,
+      duration: 604_800,
+      resetAt: now.addingTimeInterval(604_800),
+      consumedFraction: 1,
+      label: "Fable",
+    ),
+  )
+
+  #expect(
+    UsageSummary.tightestWindow(
+      in: [
+        UsageSnapshot(
+          accountID: accountID,
+          fetchedAt: now,
+          windows: [legacy, scoped],
+        )
+      ]
+    ) == TightestUsage(accountID: accountID, window: scoped),
+  )
+}

--- a/Tests/UsageMeterProbeTests/UsageMeterProbeCommandTests.swift
+++ b/Tests/UsageMeterProbeTests/UsageMeterProbeCommandTests.swift
@@ -205,4 +205,29 @@ struct UsageMeterProbeCommandTests {
 
     #expect(output.windows.first?.resetAt == nil)
   }
+
+  @Test
+  func sanitizedOutputPreservesScopedWindowLabel() throws {
+    let window = try #require(
+      UsageWindow(
+        id: "claude-weekly-scoped-6e616d653a4661626c65",
+        kind: .weekly,
+        duration: 604_800,
+        resetAt: Date(timeIntervalSince1970: 2_000_000_000),
+        consumedFraction: 0.42,
+        label: "Fable",
+      ),
+    )
+    let output = ProbeOutput(
+      provider: .claude,
+      identity: nil,
+      snapshot: UsageSnapshot(
+        accountID: accountID,
+        fetchedAt: Date(timeIntervalSince1970: 1_999_999_000),
+        windows: [window],
+      ),
+    )
+
+    #expect(output.windows == [ProbeWindow(window: window)])
+  }
 }

--- a/Tests/UsageMeterUITests/TimelinePresentationTests.swift
+++ b/Tests/UsageMeterUITests/TimelinePresentationTests.swift
@@ -409,6 +409,59 @@ struct TimelinePresentationTests {
   }
 
   @Test
+  func claudeScopedWeeklyWindowShowsItsModelLabel() throws {
+    let account = SubscriptionAccount(
+      provider: .claude,
+      displayName: "Max",
+      displayOrder: 0,
+    )
+    let resetAt = Date(timeIntervalSince1970: 2_000_472_000)
+    let weekly = try #require(
+      UsageWindow(
+        id: "seven-day",
+        kind: .weekly,
+        duration: 604_800,
+        resetAt: resetAt,
+        consumedFraction: 0.2,
+      ),
+    )
+    let fable = try #require(
+      UsageWindow(
+        id: "claude-weekly-scoped-fable",
+        kind: .weekly,
+        duration: 604_800,
+        resetAt: resetAt,
+        consumedFraction: 1,
+        label: "Fable",
+      ),
+    )
+    let state = AccountViewState(
+      account: account,
+      snapshot: UsageSnapshot(
+        accountID: account.id,
+        fetchedAt: resetAt,
+        windows: [weekly, fable],
+      ),
+    )
+
+    let section = UsageTimelineSectionPresentation(
+      kind: .weekly,
+      accounts: [state],
+      now: Date(timeIntervalSince1970: 2_000_000_000),
+      timeZone: TimeZone(secondsFromGMT: 0)!,
+    )
+
+    #expect(
+      section.rows.map(\.windowPresentation.accountText)
+        == ["Max", "Fable · Max"],
+    )
+    #expect(
+      section.rows[1].windowPresentation.accessibilityValue
+        .contains("Fable weekly window"),
+    )
+  }
+
+  @Test
   func dormantFactoryCoreWindowsStayHidden() throws {
     let account = SubscriptionAccount(
       provider: .factory,

--- a/Tests/UsageMeterUITests/TimelinePresentationTests.swift
+++ b/Tests/UsageMeterUITests/TimelinePresentationTests.swift
@@ -427,7 +427,7 @@ struct TimelinePresentationTests {
     )
     let fable = try #require(
       UsageWindow(
-        id: "claude-weekly-scoped-fable",
+        id: "claude-weekly-scoped-6e616d653a4661626c65",
         kind: .weekly,
         duration: 604_800,
         resetAt: resetAt,

--- a/docs/provider-qualification.md
+++ b/docs/provider-qualification.md
@@ -85,6 +85,25 @@ callback.
 - Fixtures and test output contain no credential, account identifier, live
   numeric balance, or raw provider response.
 
+### 2026-08-08 scoped usage-window contract qualification
+
+- Live responses from five accounts across Max and Enterprise plans were
+  inspected (values not retained in fixtures). Every account returned a
+  `limits` array containing a `weekly_scoped` entry with
+  `scope.model.display_name` "Fable" and a percent, including one account
+  where that entry was inactive; the legacy `seven_day_opus` and
+  `seven_day_sonnet` fields were null on all of them, so `limits` is the
+  only surface reporting per-model pools. `scope.model.id` was null in
+  every sample, so the display name is the only usable model identifier.
+- Sanitized fixtures now carry a `limits` array with unscoped duplicates of
+  the legacy windows, one scoped weekly entry, and one unknown-group scoped
+  entry; the decoder emits exactly one additional labeled weekly window and
+  skips the rest.
+- A malformed scoped entry, a scoped entry with an unknown group, and a
+  nonzero scoped entry without a reset are each skipped without rejecting
+  the response; a response without `limits` still yields exactly the two
+  legacy windows.
+
 ## Codex
 
 The implementation follows OpenAI Codex commit

--- a/docs/provider-qualification.md
+++ b/docs/provider-qualification.md
@@ -95,6 +95,10 @@ callback.
   `seven_day_sonnet` fields were null on all of them, so `limits` is the
   only surface reporting per-model pools. `scope.model.id` was null in
   every sample, so the display name is the only usable model identifier.
+- Scoped window ids use the provider model id when one appears and an exact
+  encoded display-name identity otherwise; display-name punctuation and case
+  must not collapse separate model pools. A model id can also label a scoped
+  pool when the provider omits its display name.
 - Sanitized fixtures now carry a `limits` array with unscoped duplicates of
   the legacy windows, one scoped weekly entry, and one unknown-group scoped
   entry; the decoder emits exactly one additional labeled weekly window and

--- a/docs/superpowers/specs/2026-08-08-claude-scoped-usage-windows-design.md
+++ b/docs/superpowers/specs/2026-08-08-claude-scoped-usage-windows-design.md
@@ -25,18 +25,29 @@ labeled subrows, and state.json only gains an additive `label` key on
 the new rows. No new `UsageWindowKind` or `UsageSectionID` raw value
 is introduced, keeping old builds and external state.json readers
 decoding — though readers that select windows by kind must prefer the
-unlabeled window now that a kind can repeat.
+unlabeled window now that a kind can repeat. Persisted and probe
+consumers should select a window by its stable `id` or by `(kind,
+label)`, not by kind alone.
+
+Each scoped identity uses `scope.model.id` when the provider supplies
+one. When it does not, the exact trimmed display name becomes the
+identity and is encoded into the stable id without lossy punctuation
+or case folding. A model id is also the display-label fallback when a
+provider omits the display name, so a valid scoped pool is not lost.
 
 Scoped entries are optional surface, not part of the qualified legacy
 contract, so they degrade by skipping rather than rejecting, at every
-level: a `limits` value that is not an array is treated as absent,
+level: a `limits` value that is not an array is recorded as malformed
+and skipped,
 an element that fails to decode is dropped, and so are out-of-range
 percents and nonzero percents without a reset (the existing
 no-invented-reset invariant). Only these malformed cases produce the
 count-only log line; unscoped entries (duplicates of the legacy
 windows) and non-weekly groups are expected surface and pass without
-logging. Entries colliding on id resolve to the higher-consumed one,
-so a duplicate can only tighten the reported limit, never hide it.
+logging. Entries colliding on identity resolve to the higher-consumed
+one; equal usage prefers a concrete reset over a resetless entry and
+then the earlier reset, so a duplicate can only tighten or clarify the
+reported limit, never hide it.
 `is_active` is ignored because the provider reports real percents on
 inactive scoped entries; `severity` is ignored because the UI has no
 severity concept. The two legacy windows keep their fail-closed rules
@@ -51,10 +62,11 @@ active, so it participates deliberately.
 
 Decoder tests pin the fixture's scoped window (kind, duration,
 fraction, label, id), the skip rules (unscoped, non-weekly group,
-malformed entry, nonzero without reset), the higher-consumed winner
-on duplicate ids, that a drifted non-array `limits` container leaves
-the legacy pair intact, and that a response without `limits` still
-yields exactly the two legacy windows. Client tests for both the
-OAuth and web paths cover the three-window shape end to end. A
-presentation test mirrors the Factory pool-label case for a Claude
-account with two weekly windows.
+malformed entry, nonzero without reset), distinct display-name and
+model-id identities, the higher-consumed and concrete-reset duplicate
+winners, that a drifted non-array `limits` container leaves the legacy
+pair intact, and that a response without `limits` still yields exactly
+the two legacy windows. Client tests for both the OAuth and web paths
+cover the three-window shape end to end. Summary, persistence, probe,
+and presentation tests make the repeated weekly-window and tightest
+badge contracts explicit.

--- a/docs/superpowers/specs/2026-08-08-claude-scoped-usage-windows-design.md
+++ b/docs/superpowers/specs/2026-08-08-claude-scoped-usage-windows-design.md
@@ -1,0 +1,52 @@
+# Claude Scoped Usage Windows
+
+## Problem
+
+The Claude usage endpoint reports per-model weekly pools — today the
+Fable share of the weekly limit — only inside the newer `limits`
+array, as entries with `"kind": "weekly_scoped"` and a
+`scope.model.display_name`. The legacy top-level fields the decoder
+reads (`five_hour`, `seven_day`) never carry them, and the legacy
+per-model fields (`seven_day_opus`, `seven_day_sonnet`) are null on
+current plans. The decoder does not declare `limits`, so the scoped
+pool is silently dropped and an account can display a comfortable
+weekly number while its Fable share is exhausted.
+
+## Design
+
+The decoder additionally decodes `limits` and emits one extra window
+per entry that has a model scope and a recognized `group` ("session"
+maps to the short shape, "weekly" to the weekly shape). The window
+reuses the existing kinds with `label` set to the model display name,
+exactly like Factory's per-pool windows, so presentation, shelf, and
+persistence need no changes: the timeline already renders repeated
+kinds as labeled subrows, and state.json only gains an additive
+`label` key on the new rows. No new `UsageWindowKind` or
+`UsageSectionID` raw value is introduced, keeping old builds and
+external state.json readers decoding.
+
+Scoped entries are optional surface, not part of the qualified legacy
+contract, so they degrade by skipping rather than rejecting:
+unscoped entries (duplicates of the legacy windows), unknown groups,
+malformed entries, duplicate ids, and nonzero percents without a
+reset are all dropped — the last per the existing no-invented-reset
+invariant — with a count-only log line. `is_active` is ignored
+because the provider reports real percents on inactive scoped
+entries; `severity` is ignored because the UI has no severity
+concept. The two legacy windows keep their fail-closed rules
+unchanged.
+
+A consequence to name: the menu-bar summary takes the tightest window
+across all snapshots, so an exhausted scoped pool now drives the
+badge. That is the binding limit the provider itself reports as
+active, so it participates deliberately.
+
+## Testing
+
+Decoder tests pin the fixture's scoped window (kind, duration,
+fraction, label, id), the skip rules (unscoped, unknown group,
+malformed entry, duplicate id, nonzero without reset), and that a
+response without `limits` still yields exactly the two legacy
+windows. Client tests for both the OAuth and web paths cover the
+three-window shape end to end. A presentation test mirrors the
+Factory pool-label case for a Claude account with two weekly windows.

--- a/docs/superpowers/specs/2026-08-08-claude-scoped-usage-windows-design.md
+++ b/docs/superpowers/specs/2026-08-08-claude-scoped-usage-windows-design.md
@@ -15,25 +15,31 @@ weekly number while its Fable share is exhausted.
 ## Design
 
 The decoder additionally decodes `limits` and emits one extra window
-per entry that has a model scope and a recognized `group` ("session"
-maps to the short shape, "weekly" to the weekly shape). The window
-reuses the existing kinds with `label` set to the model display name,
-exactly like Factory's per-pool windows, so presentation, shelf, and
-persistence need no changes: the timeline already renders repeated
-kinds as labeled subrows, and state.json only gains an additive
-`label` key on the new rows. No new `UsageWindowKind` or
-`UsageSectionID` raw value is introduced, keeping old builds and
-external state.json readers decoding.
+per entry that has a model scope and the qualified `group`
+("weekly"; other groups are unqualified surface and pass silently
+until live evidence justifies them). The window reuses the weekly
+kind with `label` set to the model display name, exactly like
+Factory's per-pool windows, so presentation, shelf, and persistence
+need no changes: the timeline already renders repeated kinds as
+labeled subrows, and state.json only gains an additive `label` key on
+the new rows. No new `UsageWindowKind` or `UsageSectionID` raw value
+is introduced, keeping old builds and external state.json readers
+decoding — though readers that select windows by kind must prefer the
+unlabeled window now that a kind can repeat.
 
 Scoped entries are optional surface, not part of the qualified legacy
-contract, so they degrade by skipping rather than rejecting:
-unscoped entries (duplicates of the legacy windows), unknown groups,
-malformed entries, duplicate ids, and nonzero percents without a
-reset are all dropped — the last per the existing no-invented-reset
-invariant — with a count-only log line. `is_active` is ignored
-because the provider reports real percents on inactive scoped
-entries; `severity` is ignored because the UI has no severity
-concept. The two legacy windows keep their fail-closed rules
+contract, so they degrade by skipping rather than rejecting, at every
+level: a `limits` value that is not an array is treated as absent,
+an element that fails to decode is dropped, and so are out-of-range
+percents and nonzero percents without a reset (the existing
+no-invented-reset invariant). Only these malformed cases produce the
+count-only log line; unscoped entries (duplicates of the legacy
+windows) and non-weekly groups are expected surface and pass without
+logging. Entries colliding on id resolve to the higher-consumed one,
+so a duplicate can only tighten the reported limit, never hide it.
+`is_active` is ignored because the provider reports real percents on
+inactive scoped entries; `severity` is ignored because the UI has no
+severity concept. The two legacy windows keep their fail-closed rules
 unchanged.
 
 A consequence to name: the menu-bar summary takes the tightest window
@@ -44,9 +50,11 @@ active, so it participates deliberately.
 ## Testing
 
 Decoder tests pin the fixture's scoped window (kind, duration,
-fraction, label, id), the skip rules (unscoped, unknown group,
-malformed entry, duplicate id, nonzero without reset), and that a
-response without `limits` still yields exactly the two legacy
-windows. Client tests for both the OAuth and web paths cover the
-three-window shape end to end. A presentation test mirrors the
-Factory pool-label case for a Claude account with two weekly windows.
+fraction, label, id), the skip rules (unscoped, non-weekly group,
+malformed entry, nonzero without reset), the higher-consumed winner
+on duplicate ids, that a drifted non-array `limits` container leaves
+the legacy pair intact, and that a response without `limits` still
+yields exactly the two legacy windows. Client tests for both the
+OAuth and web paths cover the three-window shape end to end. A
+presentation test mirrors the Factory pool-label case for a Claude
+account with two weekly windows.


### PR DESCRIPTION
Fixes #9.

## What

Claude accounts now surface per-model weekly pools — currently the Fable share of the weekly limit — as additional labeled weekly windows, decoded from the usage endpoint's `limits` array. Before this, an account could show 67% weekly while its Fable pool sat at 100%; the binding limit was invisible.

## How

The design follows the repo's existing pool-label pattern (Factory Standard/Droid Core, Copilot quota snapshots) and the provider-expansion doctrine ("multiple pools for one account are adjacent subrows with a secondary pool or model label"):

- `ClaudeUsageDecoder` decodes an optional `limits` array. Entries with a `scope.model.display_name` and the qualified `group` `"weekly"` become extra windows with `label` set to the model name and a stable id (`claude-weekly-scoped-fable`). Non-weekly groups pass silently until live evidence justifies them — only the shape observed on real accounts is emitted.
- **No new `UsageWindowKind` or `UsageSectionID`** — the scoped window reuses `.weekly` + the existing `label` field, so the timeline's repeated-kind subrow rendering, the collapsed shelf's `"% · label"` form, and the two exhaustive UI switches are untouched, and state.json changes are purely additive. External state.json readers that select windows by kind should prefer the unlabeled window now that a kind can repeat (mine needed exactly that one-line change).
- Scoped entries are optional surface, so they degrade by skipping at every level, never by rejecting: a `limits` value that isn't an array is treated as absent, an element that fails to decode is dropped (lossy per-element decode), and so are out-of-range percents and nonzero percents without a reset (the existing no-invented-reset invariant). Only these malformed cases produce the count-only log line; unscoped entries and non-weekly groups are expected surface. Entries colliding on id resolve to the higher-consumed one, so a duplicate can only tighten the reported limit, never hide it behind a stale row. The legacy `five_hour`/`seven_day` pair keeps its exact fail-closed contract.
- `is_active` is deliberately ignored: live responses show real percents on inactive scoped entries (one surveyed account reports Fable 19%, inactive). `severity` is ignored — the UI has no severity concept and inventing one here would be scope creep.
- Probe outputs (`ProbeWindow`, `ClaudeWebProbeWindow`) carry the window `label`, so scoped and all-models weekly windows stay distinguishable in qualification evidence.

## Deliberate behavior change to review

`UsageSummary.tightestWindow` is a global min, so an exhausted Fable pool now drives the menu-bar badge to 0% for that account. I'd argue that's correct — it's the limit the provider itself marks active and critical — but if you'd rather keep scoped windows out of the badge, it's a one-line filter in the summary; happy to change it.

## Evidence

Surveyed five live accounts (Max 20x and Enterprise plans): every one returns a `weekly_scoped` entry with `scope.model.display_name: "Fable"` and a percent; `seven_day_opus`/`seven_day_sonnet` are null on all of them, and `scope.model.id` is null everywhere (only the display name is populated). Payload shape and skip-rule details are in issue #9 and `docs/provider-qualification.md` (new 2026-08-08 subsection). No live values, identifiers, or raw responses were retained in fixtures.

## Review

The branch went through an independent model review before submission; it caught three things the second commit fixes: a non-array `limits` container previously failed the whole response, duplicate scoped ids kept the first (possibly staler, lower) entry, and the session-group mapping was unqualified, untested surface — now removed.

## Included

- `docs/superpowers/specs/2026-08-08-claude-scoped-usage-windows-design.md` (short Problem/Design/Testing form)
- Decoder + lossy `limits` payload structs (container- and element-level)
- Both `claude-usage.json` fixtures gain a sanitized `limits` array (unscoped duplicates + one scoped weekly + one unknown-group entry pinning the skip rule)
- Decoder tests: fixture scoped window, skip rules (unscoped/non-weekly/malformed/resetless), higher-consumed duplicate winner, drifted non-array `limits` container, no-`limits` regression
- OAuth and web client tests updated for the three-window shape
- Presentation test mirroring the Factory pool-label case ("Fable · account", "Fable weekly window" accessibility)
- Probe output label passthrough
- `docs/provider-qualification.md` Claude qualification subsection, `CHANGELOG.md` Unreleased entry

`swift test`: 424 tests, 47 suites, all passing on macOS 26 / Swift 6.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
